### PR TITLE
Needed to install package unzip on Ubuntu 12.04 for docx2txt perl script to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ I recommend using also passing +no_x11 to the install command, but this may not 
 
     apt-get install wv xpdf-utils links
 
+### Ubuntu 12.04
+
+    apt-get install wv xpdf-utils links unzip
+
 ### Perl (*sigh*)
 
 Yes, this is slightly ridiculous, but a working perl installation is required in order to extract text from a docx file.


### PR DESCRIPTION
The docx2txt perl script uses unzip, which needs to be
explicitly installed on Ubuntu 12.04, I believe.
